### PR TITLE
Wrap Closures

### DIFF
--- a/src/main/php/lang/functions/Closure.class.php
+++ b/src/main/php/lang/functions/Closure.class.php
@@ -95,4 +95,17 @@ class Closure {
       });
     }
   }
+
+  /**
+   * Wraps this closure with another closure (think: AroundInvoke)
+   *
+   * @param  var $closure
+   * @return self
+   */
+  public function wrapIn($closure) {
+    $func= Functions::$WRAP->cast($closure);
+    return new self(function($arg) use($func) {
+      return $func->__invoke($this->closure, $arg);
+    });
+  }
 }

--- a/src/main/php/lang/functions/Errors.class.php
+++ b/src/main/php/lang/functions/Errors.class.php
@@ -1,0 +1,32 @@
+<?php namespace lang\functions;
+
+use lang\Throwable;
+use lang\Error;
+
+abstract class Errors {
+
+  public static function suppress() {
+    return self::error(function($e) { return null; });
+  }
+
+  public static function handle($with) {
+    return self::error(Functions::$APPLY->cast($with));
+  }
+
+  public static function rethrow($as) {
+    $func= Functions::$APPLY->cast($as);
+    return self::error(function($e) use($func) { throw $func($e); });
+  }
+
+  private static function error($handle) {
+    return function($block, $val) use($handle) {
+      try {
+        return $block($val);
+      } catch (Throwable $e) {
+        return $handle($e);
+      } catch (\Throwable $e) {
+        return $handle(new Error(get_class($e).': '.$e->getMessage()));
+      }
+    };
+  }
+}

--- a/src/main/php/lang/functions/Errors.class.php
+++ b/src/main/php/lang/functions/Errors.class.php
@@ -3,29 +3,57 @@
 use lang\Throwable;
 use lang\Error;
 
+/**
+ * Factory for error handlers to be used in conjunction with `Closure::wrapIn()`.
+ *
+ * @test  xp://lang.functions.unittest.ErrorsTest
+ */
 abstract class Errors {
 
+  /**
+   * Suppress errors and return null
+   *
+   * @return function(php.Closure, var): var
+   */
   public static function suppress() {
-    return self::error(function($e) { return null; });
+    return self::handleWith(function($e) { return null; });
   }
 
+  /**
+   * Handle errors and return what the given handler returns
+   *
+   * @param  function(lang.Throwable): var $with The handler
+   * @return function(php.Closure, var): var
+   */
   public static function handle($with) {
-    return self::error(Functions::$APPLY->cast($with));
+    return self::handleWith(Functions::$APPLY->cast($with));
   }
 
+  /**
+   * Handle errors and throw what the given handler returns
+   *
+   * @param  function(lang.Throwable): lang.Throwable $as The handler
+   * @return function(php.Closure, var): var
+   */
   public static function rethrow($as) {
     $func= Functions::$APPLY->cast($as);
-    return self::error(function($e) use($func) { throw $func($e); });
+    return self::handleWith(function($e) use($func) { throw $func($e); });
   }
 
-  private static function error($handle) {
-    return function($block, $val) use($handle) {
+  /**
+   * Helper method for the above public methods
+   *
+   * @param  function(lang.Throwable): var $handler
+   * @return function(php.Closure, var): var
+   */
+  private static function handleWith($handler) {
+    return function($block, $val) use($handler) {
       try {
         return $block($val);
       } catch (Throwable $e) {
-        return $handle($e);
+        return $handler($e);
       } catch (\Throwable $e) {
-        return $handle(new Error(get_class($e).': '.$e->getMessage()));
+        return $handler(new Error(get_class($e).': '.$e->getMessage()));
       }
     };
   }

--- a/src/main/php/lang/functions/Functions.class.php
+++ b/src/main/php/lang/functions/Functions.class.php
@@ -8,9 +8,10 @@ use lang\Primitive;
  * Function types used throughout the library
  */
 abstract class Functions extends \lang\Object {
-  public static $APPLY, $CONSUME, $PREDICATE;
+  public static $WRAP, $APPLY, $CONSUME, $PREDICATE;
 
   static function __static() {
+    self::$WRAP= new FunctionType([Type::$VAR, Type::$VAR], Type::$VAR);
     self::$APPLY= new FunctionType([Type::$VAR], Type::$VAR);
     self::$CONSUME= new FunctionType([Type::$VAR], Type::$VOID);
     self::$PREDICATE= new FunctionType([Type::$VAR], Primitive::$BOOL);

--- a/src/test/php/lang/functions/unittest/ErrorsTest.class.php
+++ b/src/test/php/lang/functions/unittest/ErrorsTest.class.php
@@ -1,0 +1,33 @@
+<?php namespace lang\functions\unittest;
+
+use lang\functions\Closure;
+use lang\functions\Errors;
+use lang\IllegalStateException;
+use lang\MethodNotImplementedException;
+
+class ErrorsTest extends \unittest\TestCase {
+
+  #[@test]
+  public function suppress_exceptions() {
+    $fixture= function($val) { throw new IllegalStateException('Test'); };
+
+    $closure= Closure::of($fixture)->wrapIn(Errors::suppress());
+    $this->assertNull($closure(null));
+  }
+
+  #[@test]
+  public function handke_exceptions() {
+    $fixture= function($val) { throw new IllegalStateException('Test'); };
+
+    $closure= Closure::of($fixture)->wrapIn(Errors::handle(function($e) { return false; }));
+    $this->assertFalse($closure(null));
+  }
+
+  #[@test, @expect(IllegalStateException::class)]
+  public function rethrow_exceptions() {
+    $fixture= function($val) { throw new MethodNotImplementedException('Test', __FUNCTION__); };
+    $as= function($e) { return new IllegalStateException('Should not occur', $e); };
+    $closure= Closure::of($fixture)->wrapIn(Errors::rethrow($as));
+    $closure(null);
+  }
+}


### PR DESCRIPTION
This pull request adds `lang.functions.Closure::wrapIn()` and an implementation of error handling which can be used in conjunction with it. Inspired by https://github.com/diffplug/durian

``` php
use lang\functions\Closure;
use lang\functions\Errors;
use lang\Throwable;

$log= function(Throwable $e) {
  $this->cat->error('Operation failed', $e);
  throw $e;
};

Closure::of($operation)->wrapIn(Errors::handle($log))->apply($param);
```
